### PR TITLE
[✨ feat] 낙찰/유찰/패찰 기능 구현

### DIFF
--- a/apps/web/.github/workflows/cron-resolve-auction.yml
+++ b/apps/web/.github/workflows/cron-resolve-auction.yml
@@ -1,0 +1,20 @@
+# 배포 후 도메인 설정 필요
+name: Resolve Ended Auctions
+
+on:
+  schedule:
+    - cron: '*/5 * * * *' # 5분마다 실행 (UTC 기준)
+  workflow_dispatch: # 수동 실행 가능
+
+jobs:
+  create-auctions:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Call auction creation endpoint
+        run: |
+          curl -X GET "https://your-domain.com/api/cron/resolve-auctions" \
+               -H "Content-Type: application/json" \
+               -H "User-Agent: GitHub-Actions-Cron" \
+               --fail-with-body \
+               --show-error \
+               --silent

--- a/apps/web/app/api/cron/resolve-auction/route.ts
+++ b/apps/web/app/api/cron/resolve-auction/route.ts
@@ -1,0 +1,115 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { supabase } from '@/shared/lib/supabaseClient';
+
+export async function GET(request: NextRequest) {
+  try {
+    // 현재 시간을 기준으로 경매 완료 처리해야 할 auction 조회
+    const now = new Date().toISOString();
+
+    const { data: auctions, error: fetchError } = await supabase
+      .from('auction')
+      .select('*')
+      .lte('auction_end_at', now); // 경매 시간이 지난 것들
+
+    if (fetchError) {
+      console.error('auction 조회 실패:', fetchError);
+      return NextResponse.json({ success: false, error: fetchError.message }, { status: 500 });
+    }
+
+    let successCount = 0;
+    let failCount = 0;
+
+    // 각 auction에 대해 상태 update
+    for (const auction of auctions || []) {
+      try {
+        const { data: bidHistory, error: bidHistoryError } = await supabase
+          .from('bid_history')
+          .select('*')
+          .eq('auction_id', auction.auction_id)
+          .order('bid_price', { ascending: false });
+
+        if (bidHistoryError) {
+          return NextResponse.json(
+            {
+              success: false,
+              error: bidHistoryError instanceof Error ? bidHistoryError.message : 'Unknown error',
+              timestamp: new Date().toISOString(),
+            },
+            { status: 500 }
+          );
+        } else if (!bidHistory || bidHistory.length === 0) {
+          const { error } = await supabase
+            .from('auction')
+            .update({
+              auction_status: '경매 종료',
+              updated_at: new Date().toISOString(),
+            })
+            .eq('auction_id', auction.auction_id);
+          if (error) {
+            console.error('경매 상태 업데이트 실패 (유찰 처리):', error);
+          } else {
+            console.log('유찰 처리 완료');
+          }
+        } else {
+          const { error: auctionUpdateError } = await supabase
+            .from('auction')
+            .update({
+              auction_status: '경매 종료',
+              winning_bid_user_id: bidHistory[0].bid_user_id,
+              winning_bid_id: bidHistory[0].bid_id,
+              updated_at: new Date().toISOString(),
+            })
+            .eq('auction_id', auction.auction_id);
+
+          if (auctionUpdateError) {
+            console.error('낙찰자 정보 업데이트 실패:', auctionUpdateError);
+            failCount++;
+            return;
+          }
+
+          const { error: bidHistoryError } = await supabase
+            .from('bid_history')
+            .update({
+              is_awarded: true,
+            })
+            .eq('bid_id', bidHistory[0].bid_id);
+
+          if (bidHistoryError) {
+            console.error('낙찰 상태 업데이트 실패 (bid_history):', bidHistoryError);
+            failCount++;
+          } else {
+            console.log('낙찰 처리 완료');
+          }
+        }
+        successCount++;
+      } catch (error) {
+        console.error(`Product ${auction.auction_id} 처리 중 오류:`, error);
+        failCount++;
+      }
+    }
+
+    const result = {
+      success: true,
+      processed: auctions?.length || 0,
+      successCount,
+      failCount,
+      timestamp: now,
+    };
+
+    return NextResponse.json(result);
+  } catch (error) {
+    console.error('❌ Cron job 실행 중 오류:', error);
+    return NextResponse.json(
+      {
+        success: false,
+        error: error instanceof Error ? error.message : 'Unknown error',
+        timestamp: new Date().toISOString(),
+      },
+      { status: 500 }
+    );
+  }
+}
+
+export async function POST(request: NextRequest) {
+  return GET(request);
+}


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

<!-- 이슈 지울때 작성해 주세요. -->
<!-- closes #70 -->
<!-- 이슈 여러 개 일 경우, closes #1, closes #2 -->
<!-- https://docs.github.com/ko/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## 📋 작업 내용
경매 마감 일시가 지났을 때 낙찰 관련 데이터 업데이트 기능 추가
- 유찰 시 : 다른 테이블 업데이트 없이 해당 auction 데이터만 auction_status를 `경매 종료`로 변경
- 낙찰 시
  - auction 테이블은 action_status를 `경매 종료`로, winning_bid_id, winning_bid_user_id를 bid_history 기준으로 변경
  - bid_history 테이블은 최고 입찰에 대하여 is_awarded를 `true`로 변경

## 🔧 변경 사항

- [ ] 📃 README.md
- [ ] 📦 package.json
- [ ] 🔥 파일 삭제
- [ ] 🧹 그 외 ex) .gitignore 등

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷 (선택 사항)

수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부해 주세요.

## 📄 기타

- 출품 시 경매 데이터 관련과 마찬가지로 `http://localhost:3000/api/cron/resolve-auction`로 수동 테스트 가능합니다.
- 이때, auction의 auction_end_at과 현재 시간을 기준으로 판단하니 테스트 시 유의 바랍니다.
