### PR TITLE
[♻️ refactor] 뒤로가기 버튼 이벤트 구현

### DIFF
--- a/apps/web/app/(plane)/find-id/page.tsx
+++ b/apps/web/app/(plane)/find-id/page.tsx
@@ -16,7 +16,7 @@ export default function FindAccountPage() {
 
   return (
     <div className="p-box">
-      <ChevronLeft className="mt-[30px]" />
+      <ChevronLeft className="sursor-pointer mt-[30px]" onClick={() => router.back()} />
       <p className="typo-body-medium mt-[11.5rem] flex justify-center text-[1.25rem]">
         {config.title}
       </p>

--- a/apps/web/app/(plane)/login/page.tsx
+++ b/apps/web/app/(plane)/login/page.tsx
@@ -27,7 +27,7 @@ export default function LogInPage() {
 
       <div className="mt-8 flex items-center justify-center gap-1">
         <span className="font-main-text font-medium">아직 회원이 아니신가요?</span>
-        <a href="../sign/" className="text-main flex font-medium underline">
+        <a href="/signup" className="text-main flex font-medium underline">
           회원가입
         </a>
       </div>

--- a/apps/web/app/(plane)/reset-pw/page.tsx
+++ b/apps/web/app/(plane)/reset-pw/page.tsx
@@ -4,8 +4,10 @@ import { Input } from '@repo/ui/components/Input/Input';
 import { ChevronLeft, KeyIcon, Lock } from 'lucide-react';
 import { Button } from '@repo/ui/components/Button/Button';
 import { useResetPw } from '@/features/reset-pw/model/useResetPw';
+import { useRouter } from 'next/navigation';
 
 export default function ResetPasswordPage() {
+  const router = useRouter();
   const {
     newPassword,
     newPasswordConfirm,
@@ -17,7 +19,6 @@ export default function ResetPasswordPage() {
 
   return (
     <div className="m-3">
-      <ChevronLeft className="mt-[30px]" />
       <p className='className="typo-body-medium mt-[11.5rem] flex justify-center text-[1.25rem]'>
         비밀번호 재설정
       </p>

--- a/apps/web/app/(plane)/signup/page.tsx
+++ b/apps/web/app/(plane)/signup/page.tsx
@@ -1,12 +1,17 @@
+'use client';
+
 import { SignUpForm } from '../../../features/signup/SignUpForm';
 import { Button } from '@repo/ui/components/Button/Button';
 import '@repo/ui/styles.css';
 import { ChevronLeft } from 'lucide-react';
+import { useRouter } from 'next/navigation';
 
 export default function SignUpPage() {
+  const router = useRouter();
+
   return (
     <div className="p-box">
-      <ChevronLeft className="mt-[30px]" />
+      <ChevronLeft className="mt-[30px] cursor-pointer" onClick={() => router.back()} />
       <h1 className="typo-h3 mb-8 mt-28 text-center leading-[2.6rem]">회원가입</h1>
       {/* <p className="">SNS 계정으로 간편하게 회원가입</p>
 

--- a/apps/web/app/(plane)/splash/model/useSplashTimer.ts
+++ b/apps/web/app/(plane)/splash/model/useSplashTimer.ts
@@ -4,7 +4,15 @@ export const useSplashTimer = (delay = 2000) => {
   const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
+    const hasShownSplash = localStorage.getItem('hasShownSplash');
+
+    if (hasShownSplash === 'true') {
+      setIsLoading(false);
+      return;
+    }
+
     const timer = setTimeout(() => {
+      localStorage.setItem('hasShownSplash', 'true');
       setIsLoading(false);
     }, delay);
 


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

<!-- 이슈 지울때 작성해 주세요. -->
<!-- closes #147 -->
<!-- 이슈 여러 개 일 경우, closes #1, closes #2 -->
<!-- https://docs.github.com/ko/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## 📋 작업 내용

 - [ ] 회원가입, 아이디찾기/비번찾기 뒤로 가기 버튼 이벤트 구현
 - [ ] 비밀번호 재설정 페이지 뒤로 가기 버튼 삭제
 - [ ] 스플레시 1번 로딩 되도록 스플레시 타이머 수정


## 🔧 변경 사항

- [ ] apps/web/app/(plane)/find-id/page.tsx
- [ ] apps/web/app/(plane)/login/page.tsx
- [ ] apps/web/app/(plane)/reset-pw/page.tsx
- [ ] apps/web/app/(plane)/signup/page.tsx
- [ ] apps/web/app/(plane)/splash/model/useSplashTimer.ts

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷 (선택 사항)

수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부해 주세요.

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.
