### PR TITLE
[🐞 hotfix] zustand persist 재설정

### DIFF
--- a/apps/web/shared/model/authStore.ts
+++ b/apps/web/shared/model/authStore.ts
@@ -1,4 +1,5 @@
 import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
 
 interface AuthState {
   user: { id: string; email: string; nickName: string; address: string } | null;
@@ -7,15 +8,25 @@ interface AuthState {
   logout: () => void;
 }
 
-export const useAuthStore = create<AuthState>((set) => ({
-  user: null,
-  setUser: (user) => set({ user }),
-  logout: () => set({ user: null }),
-  updateAddress: (address) =>
-    set((state) => ({
-      user: {
-        ...state.user!,
-        address,
-      },
-    })),
-}));
+export const useAuthStore = create<AuthState>()(
+  persist(
+    (set) => ({
+      user: null,
+      setUser: (user) => set({ user }),
+      logout: () => set({ user: null }),
+      updateAddress: (address) =>
+        set((state) => ({
+          user: {
+            ...state.user!,
+            address,
+          },
+        })),
+    }),
+    {
+      name: 'auth-storage',
+      partialize: (state) => ({
+        user: state.user,
+      }),
+    }
+  )
+);


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

<!-- 이슈 지울때 작성해 주세요. -->
<!-- closes #191  -->
<!-- 이슈 여러 개 일 경우, closes #1, closes #2 -->
<!-- https://docs.github.com/ko/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## 📋 작업 내용

- 새로고침 하면 로그인이 끊기는 문제가 있는데, zustand는 메모리 기반이라 localStorage 같은 곳에 값을 저장해줘야 하여, 임시로 user 정보를 localStorage에 저장하는 것으로 재설정

## 📄 기타

- 추후 supabase getSession이 해결되면 localStorage에는 보안 관련 우려가 없는 닉네임, 프로필 이미지 등만 저장하거나 하는 방식으로 변경 필요
