### PR TITLE
[⚙️ chore] 릴리즈노트생성 트리거를 develop > main 에서 main > deploy로 변경 

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Auto Release
 
 on:
   push:
-    branches: [main]
+    branches: [deploy]
   workflow_dispatch:
     inputs:
       version_type:
@@ -97,7 +97,7 @@ jobs:
             git push origin ${{ steps.release-notes.outputs.NEW_VERSION }}
             echo "Created and pushed tag ${{ steps.release-notes.outputs.NEW_VERSION }}"
           fi
-          git push origin main
+          git push origin deploy
 
       - name: Create GitHub Release
         if: steps.check-release.outputs.need_release == 'true'


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

<!-- closes #238 -->

main브랜치 보호규칙때문에 ci환경에서 push가 안됨.
develop > main 은 기존처럼 pr로 merge되게 하고
deploy 브랜치를 생성하여 main 브랜치에서 deploy로 머지될때 릴리즈노트 생성되도록 변경