### PR TITLE
[🔧 fix] 개발 중인 코드의 에러도 sentry 에러로 전송되는 이슈

### DIFF
--- a/apps/web/instrumentation-client.ts
+++ b/apps/web/instrumentation-client.ts
@@ -1,28 +1,18 @@
-// This file configures the initialization of Sentry on the client.
-// The added config here will be used whenever a users loads a page in their browser.
-// https://docs.sentry.io/platforms/javascript/guides/nextjs/
-
 import * as Sentry from '@sentry/nextjs';
 
-Sentry.init({
-  dsn: 'https://64285de01a0e3029c4d7beb34d99de94@o4509705779871744.ingest.de.sentry.io/4509705874767952',
+const dsn = process.env.NEXT_PUBLIC_SENTRY_DSN;
+const isProd = process.env.NODE_ENV === 'production';
 
-  // Add optional integrations for additional features
-  integrations: [Sentry.replayIntegration(), Sentry.captureConsoleIntegration()],
-
-  // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
-  tracesSampleRate: 1,
-
-  // Define how likely Replay events are sampled.
-  // This sets the sample rate to be 10%. You may want this to be 100% while
-  // in development and sample at a lower rate in production
-  replaysSessionSampleRate: 0.1,
-
-  // Define how likely Replay events are sampled when an error occurs.
-  replaysOnErrorSampleRate: 1.0,
-
-  // Setting this option to true will print useful information to the console while you're setting up Sentry.
-  debug: false,
-});
+if (dsn && isProd) {
+  Sentry.init({
+    dsn,
+    integrations: [Sentry.replayIntegration(), Sentry.captureConsoleIntegration()],
+    tracesSampleRate: 1,
+    replaysSessionSampleRate: 0.1,
+    replaysOnErrorSampleRate: 1.0,
+    debug: false,
+    environment: process.env.NODE_ENV,
+  });
+}
 
 export const onRouterTransitionStart = Sentry.captureRouterTransitionStart;

--- a/apps/web/sentry.edge.config.ts
+++ b/apps/web/sentry.edge.config.ts
@@ -1,16 +1,13 @@
-// This file configures the initialization of Sentry for edge features (middleware, edge routes, and so on).
-// The config you add here will be used whenever one of the edge features is loaded.
-// Note that this config is unrelated to the Vercel Edge Runtime and is also required when running locally.
-// https://docs.sentry.io/platforms/javascript/guides/nextjs/
-
 import * as Sentry from '@sentry/nextjs';
 
-Sentry.init({
-  dsn: 'https://64285de01a0e3029c4d7beb34d99de94@o4509705779871744.ingest.de.sentry.io/4509705874767952',
+const dsn = process.env.NEXT_PUBLIC_SENTRY_DSN;
+const isProd = process.env.NODE_ENV === 'production';
 
-  // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
-  tracesSampleRate: 1,
-
-  // Setting this option to true will print useful information to the console while you're setting up Sentry.
-  debug: false,
-});
+if (dsn && isProd) {
+  Sentry.init({
+    dsn,
+    tracesSampleRate: 1,
+    debug: false,
+    environment: process.env.NODE_ENV,
+  });
+}

--- a/apps/web/sentry.server.config.ts
+++ b/apps/web/sentry.server.config.ts
@@ -1,15 +1,13 @@
-// This file configures the initialization of Sentry on the server.
-// The config you add here will be used whenever the server handles a request.
-// https://docs.sentry.io/platforms/javascript/guides/nextjs/
-
 import * as Sentry from '@sentry/nextjs';
 
-Sentry.init({
-  dsn: 'https://64285de01a0e3029c4d7beb34d99de94@o4509705779871744.ingest.de.sentry.io/4509705874767952',
+const dsn = process.env.NEXT_PUBLIC_SENTRY_DSN;
+const isProd = process.env.NODE_ENV === 'production';
 
-  // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
-  tracesSampleRate: 1,
-
-  // Setting this option to true will print useful information to the console while you're setting up Sentry.
-  debug: false,
-});
+if (dsn && isProd) {
+  Sentry.init({
+    dsn,
+    tracesSampleRate: 1,
+    debug: false,
+    environment: process.env.NODE_ENV,
+  });
+}


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

<!-- 이슈 지울때 작성해 주세요. -->
<!-- closes #259  -->
<!-- 이슈 여러 개 일 경우, closes #1, closes #2 -->
<!-- https://docs.github.com/ko/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## 📋 작업 내용

- 개발 중에 발생한 에러는 sentry에 요청되지 않도록 sentry 파일에 분기 처리


## 📄 기타

- 실제 NEXT_PUBLIC_SENTRY_DSN 키 값은 vercel의 [Environment Variables](https://vercel.com/choiyoungaes-projects/bider-web/settings/environment-variables)에 설정해두었습니다.
- [env 파일](https://www.notion.so/env-21da3f519ab8807d9592fddbd970ec79) 수정 필요합니다.