### PR TITLE
[🐞 hotfix] 출품하기 이미지 삭제 버튼 크기 에러

### DIFF
--- a/apps/web/shared/lib/ImageUploadPreview.tsx
+++ b/apps/web/shared/lib/ImageUploadPreview.tsx
@@ -144,7 +144,7 @@ const ImageUploadPreview = ({ exImages, onImagesChange }: ImageUploadPreviewProp
             )}
             <Button
               size="icon"
-              className="absolute right-1 top-1 h-[20px] w-[20px] -translate-y-1/2 translate-x-1/2 rounded-full bg-neutral-800"
+              className="absolute right-1 top-1 size-[20px] -translate-y-1/2 translate-x-1/2 rounded-full bg-neutral-800"
               onClick={() => removeImage(image.id)}
             >
               <X size={12} />


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

<!-- 이슈 지울때 작성해 주세요. -->
<!-- closes #281  -->
<!-- 이슈 여러 개 일 경우, closes #1, closes #2 -->
<!-- https://docs.github.com/ko/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## 📋 작업 내용

h-[20px] w-[20px]로 크기 설정해주던 부분이 button 컴포넌트의 icon size="icon" 값에 무시되었어서 size-[20px]로 수정

## 📸 스크린샷 (선택 사항)

전
<img width="137" height="95" alt="Image" src="https://github.com/user-attachments/assets/418beb4c-4681-471f-bce2-08f7ac04f7ff" />
후
<img width="93" height="83" alt="image" src="https://github.com/user-attachments/assets/cdb7ae9f-9735-4bd0-9ec5-fcdb4b3c8d4f" />


## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.
