### PR TITLE
[🐞 hotfix] 출품하기에 사진을 등록할 때 첫번째로 등록한 사진이 실제 메인이미지로 등록되지 않는 이슈

### DIFF
--- a/apps/web/features/auction/detail/ui/ProductImageSlider.tsx
+++ b/apps/web/features/auction/detail/ui/ProductImageSlider.tsx
@@ -15,6 +15,8 @@ export default function ProductImageSlider({ images }: Props) {
   const [activeIndex, setActiveIndex] = useState(0);
   const swiperRef = useRef<SwiperType | null>(null);
 
+  const sortedImages = [...images].sort((a, b) => a.order_index - b.order_index);
+
   return (
     <div className="w-full">
       {/* Main Swiper */}
@@ -28,7 +30,7 @@ export default function ProductImageSlider({ images }: Props) {
           onSlideChange={(swiper) => setActiveIndex(swiper.activeIndex)}
           className="h-full p-0"
         >
-          {images.map((img) => (
+          {sortedImages.map((img) => (
             <SwiperSlide key={img.image_id} className="flex items-center justify-center">
               <img
                 src={img.image_url}
@@ -42,7 +44,7 @@ export default function ProductImageSlider({ images }: Props) {
 
       {/* Thumbnail Gallery */}
       <div className="p-box mt-4 flex justify-between">
-        {images.map((img, idx) => (
+        {sortedImages.map((img, idx) => (
           <button
             key={img.image_id}
             onClick={() => {


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

<!-- 이슈 지울때 작성해 주세요. -->
<!-- closes #285  -->
<!-- 이슈 여러 개 일 경우, closes #1, closes #2 -->
<!-- https://docs.github.com/ko/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## 📋 작업 내용

- 경매상품 상세보기에서 메인이미지가 첫번째 이미지로 보이도록 순서 지정
