### PR TITLE
[🐞 hotfix] 입찰 후 상세페이지 조회 시 직전 입찰이 반영되지 않은 화면 이슈

### DIFF
--- a/apps/web/features/auction/bids/model/useBidSubmit.ts
+++ b/apps/web/features/auction/bids/model/useBidSubmit.ts
@@ -2,12 +2,13 @@ import { useAuthStore } from '@/shared/model/authStore';
 import { toast } from '@repo/ui/components/Toast/Sonner';
 import { parseBidPrice, validateBidPrice } from '../lib/utils';
 import { submitBid } from '../api/doBid';
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { BidResponse, SubmitBidContext } from '../types';
 import { useBidStore } from '@/features/auction/bids/model/bidStore';
 import { useRouter } from 'next/navigation';
 
 export const useBidSubmit = (shortId: string) => {
+  const queryClient = useQueryClient();
   const user = useAuthStore();
   const router = useRouter();
   const { setBidInfo } = useBidStore();
@@ -29,6 +30,10 @@ export const useBidSubmit = (shortId: string) => {
       });
     },
     onSuccess: (result, _, context) => {
+      queryClient.invalidateQueries({
+        queryKey: ['auctionDetail', shortId],
+      });
+
       const bidData = result.bidData;
       if (bidData) {
         setBidInfo({

--- a/apps/web/features/auction/detail/api/useBidHistoryRealtime.ts
+++ b/apps/web/features/auction/detail/api/useBidHistoryRealtime.ts
@@ -1,8 +1,6 @@
 import { useEffect } from 'react';
 import { anonSupabase } from '@/shared/lib/supabaseClient';
 import { BidHistory, BidHistoryWithUserNickname } from '@/entities/bidHistory/model/types';
-import { useQueryClient } from '@tanstack/react-query';
-import { encodeUUID } from '@/shared/lib/shortUuid';
 
 export function useBidHistoryRealtime({
   auctionId,
@@ -11,8 +9,6 @@ export function useBidHistoryRealtime({
   auctionId: string;
   onNewBid: (newBid: BidHistoryWithUserNickname) => void;
 }) {
-  const queryClient = useQueryClient();
-
   useEffect(() => {
     const channel = anonSupabase
       .channel('bid_history_changes')
@@ -26,10 +22,6 @@ export function useBidHistoryRealtime({
         },
         async (payload) => {
           const newBid = payload.new;
-
-          queryClient.invalidateQueries({
-            queryKey: ['auctionDetail', encodeUUID(auctionId)],
-          });
 
           const { data: profiles, error } = await anonSupabase
             .from('profiles')


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

<!-- 이슈 지울때 작성해 주세요. -->
<!-- closes #308  -->
<!-- 이슈 여러 개 일 경우, closes #1, closes #2 -->
<!-- https://docs.github.com/ko/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## 📋 작업 내용

- 입찰 완료 시 해당 상품에 대한 조회 캐시를 삭제하도록 로직 위치 변경