### PR TITLE
[✨ design] 채팅 목록 대화 미리보기 css수정

### DIFF
--- a/apps/web/features/chat/list/ui/ChatItem.tsx
+++ b/apps/web/features/chat/list/ui/ChatItem.tsx
@@ -9,7 +9,7 @@ import { getTimeAgo } from '../lib/getTimeAgo';
 const ChatItem = ({ data, isLastMsgMine }: ChatItemProps) => {
   return (
     <div className="bg-neutral-0 flex w-full items-center justify-between py-[17px]">
-      <div className="flex items-center">
+      <div className="flex w-full items-center">
         <div className="relative size-[46px] overflow-hidden rounded">
           <Image
             src={data.product_image.image_url}
@@ -19,17 +19,17 @@ const ChatItem = ({ data, isLastMsgMine }: ChatItemProps) => {
             className="object-cover object-center"
           />
         </div>
-        <div className="ml-[15px] flex flex-col gap-[6px]">
+        <div className="ml-[15px]" style={{ width: 'calc(100% - 61px)' }}>
           <div className="flex items-center gap-[7px]">
             <Avatar className="size-[18px]" src={data.your_profile.profile_img || undefined} />
             <div className="typo-body-medium">{data.your_profile.nickname}</div>
             {data.is_win && <StatusBadge type="state-blue" label="낙찰" />}
           </div>
-          <div>
+          <div className="relative mt-[6px] w-full">
             {data.last_message ? (
               <div className="flex">
                 <div
-                  className={`typo-caption-regular max-w-[40vw] truncate ${
+                  className={`typo-caption-regular max-w-[70%] truncate ${
                     data.last_message?.is_read || isLastMsgMine ? 'text-neutral-400' : ''
                   }`}
                 >


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

closes #389 

## 📋 작업 내용

채팅 목록 대화 미리보기 css 수정

## 🔧 변경 사항

- [ ] 채팅 목록 대화 미리보기에 말 줄임 길이 일정하게 수정

## 📸 스크린샷 (선택 사항)
<img width="387" height="840" alt="스크린샷 2025-08-05 오후 2 56 59" src="https://github.com/user-attachments/assets/dbbd9886-12cf-44a0-b903-87824bad45c6" />

<img width="948" height="962" alt="스크린샷 2025-08-05 오후 2 57 06" src="https://github.com/user-attachments/assets/67c502c3-e5b8-4790-bd05-8cf418ff0002" />


## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.
