### PR TITLE
[🐞 hotfix] 시크릿경매 입찰현황판 최고입찰가만 노출

### DIFF
--- a/apps/web/features/auction/detail/ui/BiddingStatusBoard.tsx
+++ b/apps/web/features/auction/detail/ui/BiddingStatusBoard.tsx
@@ -32,13 +32,14 @@ const BiddingStatusBoard = ({
   if (bidData.length === 0) {
     return <div className="text-center">아직 입찰자가 없습니다. 첫 입찰자가 되어보세요!</div>;
   }
+  const bidDataLength = isSecret ? 1 : 5;
 
   return (
     <div>
-      {bidData.slice(0, 5).map((bid, index) => (
+      {bidData.slice(0, bidDataLength).map((bid, index) => (
         <div
           key={bid.bid_id}
-          className={`flex justify-between border-b border-dashed border-neutral-300 px-[16px] py-[9px] ${
+          className={`flex justify-between ${!isSecret && `border-b`} border-dashed border-neutral-300 px-[16px] py-[9px] ${
             index === 0 ? `${pointColor} typo-body-bold` : 'text-neutral-700'
           }`}
         >

--- a/apps/web/features/auction/secret/actions/checkSecretViewHistory.ts
+++ b/apps/web/features/auction/secret/actions/checkSecretViewHistory.ts
@@ -7,7 +7,7 @@ import { supabase } from '@/shared/lib/supabaseClient';
 export default async function checkSecretViewHistory(
   auctionId: string
 ): Promise<SecretViewHistory> {
-  const userId = getUserId();
+  const userId = await getUserId();
 
   if (!userId) {
     return { hasPaid: false, isValid: false };


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안
시크릿경매 입찰현황판에 최고 입찰가만 노출되게 수정
10분이내 최고입찰가 확인하기 버튼 클릭시 다시 포인트 사용해야하는 버그 수정

## 📸 스크린샷 (선택 사항)

<img width="330" height="156" alt="image" src="https://github.com/user-attachments/assets/08a8c6a1-48f3-4d27-afe8-984c474e2bfb" />


<!-- closes #420 -->

