### PR TITLE
[✨ feat] 이미지 클릭 시 전체화면으로 이미지 보는 기능 추가

### DIFF
--- a/apps/web/features/auction/detail/ui/ProductImageSlider.tsx
+++ b/apps/web/features/auction/detail/ui/ProductImageSlider.tsx
@@ -8,6 +8,7 @@ import 'swiper/css/pagination';
 import type { Swiper as SwiperType } from 'swiper';
 import { ProductImage } from '@/entities/productImage/model/types';
 import Image from 'next/image';
+import ImageViewer from '@/shared/lib/ImageViewer';
 
 interface Props {
   images: ProductImage[];
@@ -16,8 +17,10 @@ interface Props {
 export default function ProductImageSlider({ images }: Props) {
   const [activeIndex, setActiveIndex] = useState(0);
   const swiperRef = useRef<SwiperType | null>(null);
+  const [isViewerOpen, setIsViewerOpen] = useState(false);
 
   const sortedImages = [...images].sort((a, b) => a.order_index - b.order_index);
+  const imageUrls = sortedImages.map((img) => img.image_url);
 
   return (
     <div className="w-full">
@@ -47,6 +50,7 @@ export default function ProductImageSlider({ images }: Props) {
                 sizes="100vw"
                 className="mx-auto"
                 priority
+                onClick={() => setIsViewerOpen(true)}
               />
             </SwiperSlide>
           ))}
@@ -80,6 +84,14 @@ export default function ProductImageSlider({ images }: Props) {
           <div key={`empty-${idx}`} className="pointer-events-none h-16 w-16 shrink-0 opacity-0" />
         ))}
       </div>
+
+      {isViewerOpen && (
+        <ImageViewer
+          images={imageUrls}
+          initialIndex={activeIndex}
+          onClose={() => setIsViewerOpen(false)}
+        />
+      )}
     </div>
   );
 }

--- a/apps/web/shared/lib/ImageViewer.tsx
+++ b/apps/web/shared/lib/ImageViewer.tsx
@@ -1,0 +1,68 @@
+'use client';
+
+import { Swiper, SwiperSlide } from 'swiper/react';
+import { Zoom, Navigation } from 'swiper/modules';
+import 'swiper/css';
+import 'swiper/css/zoom';
+import 'swiper/css/navigation';
+import { useEffect, useCallback } from 'react';
+import { X } from 'lucide-react';
+
+interface ImageViewerProps {
+  images: string[];
+  initialIndex?: number;
+  onClose: () => void;
+}
+
+export default function ImageViewer({ images, initialIndex = 0, onClose }: ImageViewerProps) {
+  useEffect(() => {
+    document.body.style.overflow = 'hidden';
+    return () => {
+      document.body.style.overflow = '';
+    };
+  }, []);
+
+  return (
+    <div className="fixed inset-0 z-[100] flex items-center justify-center bg-neutral-900">
+      {/* 닫기 버튼 */}
+      <button
+        className="absolute right-4 top-4 z-[110] cursor-pointer text-white"
+        onClick={onClose}
+      >
+        <X size={30} />
+      </button>
+
+      {/* Swiper 컨테이너 */}
+      <div
+        className="relative h-full w-full"
+        style={
+          {
+            '--swiper-navigation-color': '#ffffff',
+            '--swiper-navigation-size': '30px',
+            '--swiper-navigation-sides-offset': '20px',
+          } as React.CSSProperties
+        }
+      >
+        <Swiper
+          modules={[Zoom, Navigation]}
+          zoom
+          navigation
+          initialSlide={initialIndex}
+          className="h-full w-full"
+        >
+          {images.map((src, idx) => (
+            <SwiperSlide key={idx}>
+              <div className="swiper-zoom-container flex h-full w-full items-center justify-center">
+                <img
+                  src={src}
+                  alt={`img-${idx}`}
+                  className="max-h-full max-w-full object-contain"
+                />
+              </div>
+            </SwiperSlide>
+          ))}
+        </Swiper>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

<!-- 이슈 지울때 작성해 주세요. -->
<!-- closes #445  -->
<!-- 이슈 여러 개 일 경우, closes #1, closes #2 -->
<!-- https://docs.github.com/ko/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## 📋 작업 내용

- 사진 클릭 시 전체화면으로 조회할 수 있는 기능 추가. 사진 확대/축소 가능
- 상품 상세페이지 메인이미지에 적용
- 추후 채팅 이미지에 적용 예정

## 🔧 변경 사항

- [ ] 📃 README.md
- [ ] 📦 package.json
- [ ] 🔥 파일 삭제
- [ ] 🧹 그 외 ex) .gitignore 등

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷 (선택 사항)
<img width="1916" height="885" alt="image" src="https://github.com/user-attachments/assets/11efecff-c45a-401f-8665-48ad79b54f1c" />

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.
