### PR TITLE
[🔧 fix] 나가기 처리된 채팅방의 미읽은 메시지가 nav 표시 조건에 포함되는 문제 수정

### DIFF
--- a/apps/web/features/chat/nav/api/useUnreadMessagesCount.ts
+++ b/apps/web/features/chat/nav/api/useUnreadMessagesCount.ts
@@ -1,27 +1,26 @@
 import { createClient } from '@/shared/lib/supabase/client';
 import { useAuthStore } from '@/shared/model/authStore';
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
+import { useUnreadStore } from '../model/unreadStore';
 
 export const useUnreadMessagesCount = () => {
-  const [unreadCount, setUnreadCount] = useState(0);
   const userId = useAuthStore((state) => state.user?.id) as string;
   const supabase = createClient();
+  const { setCount, increase, decrease } = useUnreadStore();
 
   useEffect(() => {
     if (!userId) return;
 
     // 1. 초기 읽지 않은 메세지 수 가져오기
     const fetchInitialUnreadMessages = async () => {
-      const { count, error } = await supabase
-        .from('message')
-        .select('message_id', { count: 'exact' })
-        .eq('is_read', false)
-        .neq('sender_id', userId);
+      const { data, error } = await supabase.rpc('get_unread_message_count', {
+        user_id: userId,
+      });
 
       if (error) {
         throw new Error('읽지 않은 메세지 수 초기 조회 실패', error);
       }
-      setUnreadCount(count || 0);
+      setCount(data || 0);
     };
 
     fetchInitialUnreadMessages();
@@ -39,12 +38,13 @@ export const useUnreadMessagesCount = () => {
       (payload) => {
         const newMessage = payload.new;
         if (newMessage.sender_id !== userId && newMessage.is_read === false) {
-          setUnreadCount((prevCount) => prevCount + 1);
+          increase(1);
         }
       }
     );
 
-    // UPDATE 감지 → is_read: false → true로 바뀐 경우에만 감소
+    // UPDATE 감지
+    // 1. is_read: false → true로 바뀐 경우 감소
     channel.on(
       'postgres_changes',
       {
@@ -61,7 +61,40 @@ export const useUnreadMessagesCount = () => {
 
         // 내가 받은 메시지면서 읽음 처리된 경우만 처리
         if (newMessage.sender_id !== userId && wasUnread && nowRead) {
-          setUnreadCount((prev) => Math.max(prev - 1, 0));
+          decrease(1);
+        }
+      }
+    );
+
+    // 2. 채팅방 나가기(활성 상태 변경) 감지
+    channel.on(
+      'postgres_changes',
+      {
+        event: 'UPDATE',
+        schema: 'public',
+        table: 'chat_room',
+      },
+      async (payload) => {
+        const oldRoom = payload.old;
+        const newRoom = payload.new;
+
+        // 내가 나간 경우만 감지 (bid_user인지 exhibit_user인지에 따라)
+        const isSelfLeaved =
+          (newRoom.bid_user_id === userId && newRoom.bid_user_active === false) ||
+          (newRoom.exhibit_user_id === userId && newRoom.exhibit_user_active === false);
+
+        if (!isSelfLeaved) return;
+
+        // 3. 내가 나간 방의 미읽은 메시지 수 계산
+        const { count, error } = await supabase
+          .from('message')
+          .select('message_id', { count: 'exact' })
+          .eq('chatroom_id', newRoom.chatroom_id)
+          .eq('is_read', false)
+          .neq('sender_id', userId);
+
+        if (!error && count && count > 0) {
+          decrease(count);
         }
       }
     );
@@ -71,5 +104,4 @@ export const useUnreadMessagesCount = () => {
       supabase.removeChannel(channel);
     };
   }, [userId]);
-  return unreadCount;
 };

--- a/apps/web/features/chat/nav/model/unreadStore.ts
+++ b/apps/web/features/chat/nav/model/unreadStore.ts
@@ -1,0 +1,17 @@
+import { create } from 'zustand';
+
+type UnreadState = {
+  count: number;
+  setCount: (value: number) => void;
+  increase: (n?: number) => void;
+  decrease: (n?: number) => void;
+  reset: () => void;
+};
+
+export const useUnreadStore = create<UnreadState>((set) => ({
+  count: 0,
+  setCount: (value) => set({ count: value }),
+  increase: (n = 1) => set((state) => ({ count: state.count + n })),
+  decrease: (n = 1) => set((state) => ({ count: Math.max(state.count - n, 0) })),
+  reset: () => set({ count: 0 }),
+}));

--- a/apps/web/widgets/nav/Nav.tsx
+++ b/apps/web/widgets/nav/Nav.tsx
@@ -12,6 +12,7 @@ import {
 } from 'lucide-react';
 import AlertBadge from '@/shared/ui/badge/AlertBadge';
 import { useUnreadMessagesCount } from '@/features/chat/nav/api/useUnreadMessagesCount';
+import { useUnreadStore } from '@/features/chat/nav/model/unreadStore';
 
 interface NavItems {
   href: string;
@@ -55,8 +56,10 @@ const navItems: NavItems[] = [
 
 const Nav = () => {
   const pathname = usePathname();
-  const unreadCount = useUnreadMessagesCount();
+  const unreadCount = useUnreadStore((state) => state.count);
   const hasNewChat = unreadCount > 0; //새로운 채팅 여부 받아오기
+
+  useUnreadMessagesCount();
 
   return (
     <nav className="bg-neutral-0 p-box fixed bottom-0 left-1/2 z-20 flex w-full max-w-[600px] translate-x-[-50%] items-baseline justify-between border-t border-neutral-100 pb-[40px] pt-[13px]">


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

<!-- 이슈 지울때 작성해 주세요. -->
<!-- closes #451  -->
<!-- 이슈 여러 개 일 경우, closes #1, closes #2 -->
<!-- https://docs.github.com/ko/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## 📋 작업 내용

- 비활성화된 채팅방까지 포함되던 문제
- 채팅방 나가기 시 카운트가 제대로 반영되지 않던 문제

## 🔧 변경 사항

- zustand를 활용하여 안 읽은 메세지의 수 상태 관리

## 📸 스크린샷 (선택 사항)

수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부해 주세요.

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.
